### PR TITLE
Add Redis Sentinel support

### DIFF
--- a/resque_exporter/__init__.py
+++ b/resque_exporter/__init__.py
@@ -34,6 +34,15 @@ def main():
     parser.add_argument('-r', '--redis-url', dest='redis_url', type=str,
                         default=os.getenv('RESQUE_EXPORTER_REDIS_URL', 'redis://localhost'),
                         help="Redis URL")
+    parser.add_argument('--redis-sentinel-hosts', dest='redis_sentinel_hosts', type=str,
+                        default=os.getenv('RESQUE_EXPORTER_REDIS_SENTINEL_HOSTS'),
+                        help="Redis Sentinel hosts, e.g. 'host1:26379,host2:26379'")
+    parser.add_argument('--redis-sentinel-masterset', dest='redis_sentinel_masterset', type=str,
+                        default=os.getenv('RESQUE_EXPORTER_REDIS_SENTINEL_MASTERSET'),
+                        help="Redis Sentinel master name")
+    parser.add_argument('--redis-password', dest='redis_password', type=str,
+                        default=os.getenv('RESQUE_EXPORTER_REDIS_PASSWORD'),
+                        help="Redis password")
     parser.add_argument('-n', '--redis-namespace', dest='redis_ns', type=str,
                         default=os.getenv('RESQUE_EXPORTER_REDIS_NS'), help="Redis namespace")
     parser.add_argument('-p', '--port', dest='port', type=int,
@@ -61,6 +70,9 @@ def main():
         args.redis_url,
         namespace=args.redis_ns,
         custom_metrics=args.custom_metrics,
+        redis_sentinel_hosts=args.redis_sentinel_hosts,
+        redis_sentinel_masterset=args.redis_sentinel_masterset,
+        redis_password=args.redis_password,
     )
 
     REGISTRY.register(r_collector)

--- a/resque_exporter/collector.py
+++ b/resque_exporter/collector.py
@@ -110,10 +110,8 @@ class ResqueCollector:
                 sentinel_hosts,
                 sentinel_kwargs={'password': redis_password} if redis_password else {},
             )
-            master_host, master_port = sentinel.discover_master(redis_sentinel_masterset or 'mymaster')
-            return redis.StrictRedis(
-                host=master_host,
-                port=master_port,
+            return sentinel.master_for(
+                redis_sentinel_masterset or 'mymaster',
                 password=redis_password if redis_password else None,
                 encoding="utf-8",
                 decode_responses=True,

--- a/resque_exporter/collector.py
+++ b/resque_exporter/collector.py
@@ -4,6 +4,7 @@ import threading
 import time
 
 import redis
+import redis.sentinel
 from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
 
 RESQUE_NAMESPACE_PREFIX = 'resque'
@@ -58,8 +59,20 @@ class RedisWildcardLookup:
 
 
 class ResqueCollector:
-    def __init__(self, redis_url, namespace=None, custom_metrics=None):
-        self._r = redis.from_url(redis_url, encoding="utf-8", decode_responses=True)
+    def __init__(
+        self, redis_url,
+        namespace=None,
+        custom_metrics=None,
+        redis_sentinel_hosts=None,
+        redis_sentinel_masterset=None,
+        redis_password=None,
+    ):
+        self._r = self._get_redis_client(
+            redis_url,
+            redis_sentinel_hosts=redis_sentinel_hosts,
+            redis_sentinel_masterset=redis_sentinel_masterset,
+            redis_password=redis_password
+        )
         self._r_namespace = namespace
         self.queues = []
         self.workers = []
@@ -81,6 +94,31 @@ class ResqueCollector:
                     'redis_pattern': cm['redis_pattern'],
                     'label_regex': label_regex,
                 })
+
+    def _get_redis_client(
+        self, redis_url,
+        redis_sentinel_hosts=None,
+        redis_sentinel_masterset=None,
+        redis_password=None,
+    ):
+        if redis_url:
+            return redis.from_url(redis_url, encoding="utf-8", decode_responses=True)
+        elif redis_sentinel_hosts:
+            # convert "host1:port1,host2:port2" to format [(host1, port1), (host2, port2)]
+            sentinel_hosts = [(url.split(':')[0], int(url.split(':')[1])) for url in redis_sentinel_hosts.split(',')]
+            sentinel = redis.sentinel.Sentinel(
+                sentinel_hosts,
+                sentinel_kwargs={'password': redis_password} if redis_password else {},
+            )
+            master_host, master_port = sentinel.discover_master(redis_sentinel_masterset or 'mymaster')
+            return redis.StrictRedis(
+                host=master_host,
+                port=master_port,
+                password=redis_password if redis_password else None,
+                encoding="utf-8",
+                decode_responses=True,
+            )
+        raise ValueError("No Redis URL or Sentinel configuration provided")
 
     def _r_key(self, key):
         if self._r_namespace:


### PR DESCRIPTION
In order to switch API to Redis Sentinel, we need to update the Resque exporter too.